### PR TITLE
Add blank filter to generator

### DIFF
--- a/src/EnvMapper/Generator.re
+++ b/src/EnvMapper/Generator.re
@@ -47,6 +47,11 @@ let genCM: its = ({namespace, cm}) => {
     env
       |> Js.String.split("\n")
       |> Array.to_list
+      |> List.filter(line =>
+        line
+          ->String.trim
+          ->String.length != 0
+        )
       |> List.map(line =>
         line
           ->StrUtils.keyValueOf
@@ -84,6 +89,11 @@ let genSecret: its = ({namespace, secret}) => {
     env
       |> Js.String.split("\n")
       |> Array.to_list
+      |> List.filter(line =>
+        line
+          ->String.trim
+          ->String.length != 0
+        )
       |> List.map(line =>
         line
           ->StrUtils.keyValueOf
@@ -130,6 +140,11 @@ let genSnippet: its = ({cm, secret}) => {
     env
       |> Js.String.split("\n")
       |> Array.to_list
+      |> List.filter(line =>
+        line
+          ->String.trim
+          ->String.length != 0
+        )
       |> List.map(line =>
         line
           ->StrUtils.keyValueOf

--- a/src/EnvMapper/Generator.re
+++ b/src/EnvMapper/Generator.re
@@ -22,6 +22,8 @@ type base64; /* abstract type for a document object */
 
 let encode = str => encodeBase64(base64, str);
 
+let filterBlankStr = str => str->String.trim->String.length != 0;
+
 let indent = (text, indenter) =>
   text
     |> Js.String.split("\n")
@@ -47,11 +49,7 @@ let genCM: its = ({namespace, cm}) => {
     env
       |> Js.String.split("\n")
       |> Array.to_list
-      |> List.filter(line =>
-        line
-          ->String.trim
-          ->String.length != 0
-        )
+      |> List.filter(filterBlankStr)
       |> List.map(line =>
         line
           ->StrUtils.keyValueOf
@@ -89,11 +87,7 @@ let genSecret: its = ({namespace, secret}) => {
     env
       |> Js.String.split("\n")
       |> Array.to_list
-      |> List.filter(line =>
-        line
-          ->String.trim
-          ->String.length != 0
-        )
+      |> List.filter(filterBlankStr)
       |> List.map(line =>
         line
           ->StrUtils.keyValueOf
@@ -140,11 +134,7 @@ let genSnippet: its = ({cm, secret}) => {
     env
       |> Js.String.split("\n")
       |> Array.to_list
-      |> List.filter(line =>
-        line
-          ->String.trim
-          ->String.length != 0
-        )
+      |> List.filter(filterBlankStr)
       |> List.map(line =>
         line
           ->StrUtils.keyValueOf

--- a/test/env-mapper.js
+++ b/test/env-mapper.js
@@ -10,11 +10,16 @@ describe('generate EnvMapper', () => {
     const input = {
       namespace: "my-namespace",
       cmName: "new-cm",
-      cmEnv: `key=value
-key2=value2`,
+      cmEnv: `
+      key=value
+
+      key2=value2
+      `,
       secretName: "new-secret",
-      secretEnv: `key=value
-key2=value2`
+      secretEnv: `
+      key=value
+      key2=value2
+      `
     };
 
     const output = {
@@ -58,16 +63,6 @@ metadata:
               name: new-secret`,
       errMsg: undefined
     };
-
-    function compareDetail(o, o2) {
-      const {cm, secret, envSnippet, errMsg} = o
-      const {cm: cm2, secret: s2, envSnippet: e2, errMsg: em2} = o2
-
-      return cm==cm2
-        && secret==s2
-        && envSnippet==e2
-        && errMsg==em2
-    }
 
     it('should be same with pregenerated output', () => {
       assert(_.isEqual(generate(input), output));


### PR DESCRIPTION
> Resolves https://github.com/Rainist/galley/issues/5

If blank line is provided as input, generator throws exception, but it seems blank string is not exception or error.
So I suggest to filtering blank line, which may not confuse users.

![image](https://user-images.githubusercontent.com/6194958/60779714-bec05780-a176-11e9-9220-eaf1451de4f8.png)
